### PR TITLE
Added migrations folder in classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
 		}
 	],
 	"autoload": {
+		"classmap": [
+			"src/migrations"
+		],
 		"psr-4": {
 			"Orchestra\\Control\\" : "src/Control"
 		}


### PR DESCRIPTION
Fixing the "Class 'OrchestraControlSeedAcls' not found" error on migrate:rollback
