### PR TITLE
[RFC] Fix ControlMenuHandler authorize method

### DIFF
--- a/src/Http/Handlers/ControlMenuHandler.php
+++ b/src/Http/Handlers/ControlMenuHandler.php
@@ -36,6 +36,6 @@ class ControlMenuHandler extends MenuHandler
      */
     public function authorize(Authorization $acl)
     {
-        return ($acl->can('manage roles') || $acl->can('manage acl'));
+        return ($acl->canIf('manage roles') || $acl->canIf('manage acl'));
     }
 }


### PR DESCRIPTION
Hi,

I did a fresh Orchestra Platform install and after the initial setup I started activating extensions.
As soon as I activated the **Control Extension**, I got a `InvalidArgumentException` in the `AuthorizationTrait.php` with the following message:

`Unable to verify unknown action manage roles.` (line `61`).

I had a look at other `*MenuHandler` classes and in all of them, the `authorize()` method is checking the ACL with the `canIf()` method, while in this particular case the `can()` is being used.
Using `canIf()` fixed my issue, but I don't know if using `can()` was actually intended.

Let me know what you think.

Cheers,
Quetzy