### PR TITLE
Return the right value

### DIFF
--- a/src/Http/Handlers/ControlMenuHandler.php
+++ b/src/Http/Handlers/ControlMenuHandler.php
@@ -43,6 +43,6 @@ class ControlMenuHandler extends MenuHandler
      */
     public function authorize(Authorization $acl)
     {
-        return $acl->canIf('manage acl');
+        return $acl->canIf('manage acl') || $acl->canIf('manage roles') || $acl->canIf('manage orchestra');
     }
 }

--- a/src/Http/Handlers/ControlMenuHandler.php
+++ b/src/Http/Handlers/ControlMenuHandler.php
@@ -43,6 +43,6 @@ class ControlMenuHandler extends MenuHandler
      */
     public function authorize(Authorization $acl)
     {
-        return true;
+        return $acl->canIf('manage acl');
     }
 }


### PR DESCRIPTION
Instead of always return `true`, check for the ACL before showing the menu.
